### PR TITLE
Added README describing the tool.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,15 @@ First, you'll need to install it, most likely as a `devDependency` of your `npm`
 $ npm install --save-dev koa-karma-proxy
 ```
 
-Create a file called `karma.proxy.js` and export a function that returns a Koa app, which will define your proxy server.  Be sure to slot in the provided proxy to karma, which is the single given parameter, named `"karma"` in the example below.  In this example, we'll use the [`koa-node-resolve`](https://github.com/Polymer/koa-node-resolve) package to translate node bare module specifiers to relative paths on-the-fly.  Please note that we mount the `nodeResolve` middleware specifically to the `/base` sub-path, since that is where `karma` serves our test, source and `node_modules` files from:
+Create a file called `karma.proxy.js` and export a function that returns a Koa app, which will define your proxy server. Be sure to slot in the provided proxy to karma, which is the single given parameter, named "karma" in the example below:
+
+```js
+const Koa = require('koa');
+const someMiddleaware = require('./some-middleware.js');
+module.exports = (karma) => new Koa().use(someMiddleware).use(karma);
+```
+
+In the following example, we'll use the [`koa-node-resolve`](https://github.com/Polymer/koa-node-resolve) package to translate node bare module specifiers to relative paths on-the-fly. Please note that we mount the nodeResolve middleware specifically to the `/base` sub-path, since that is where karma serves our test, source and `node_modules` files from:
 
 ```js
 const Koa = require('koa');


### PR DESCRIPTION
In the `lit-element` branch `switch-to-karma` there is a file called `run-karma-with-proxy.ts` that looks like this: (*NOTE, you don't have to read and grok the whole thing-- just appreciate it as many-lines-of-ugly-code*)

```ts
const path = require('path');
const karma = require('karma');
const portfinder = require('portfinder');
const Koa = require('koa');
const mount = require('koa-mount');
const proxy = require('koa-proxy');
const nodeResolve = require('koa-node-resolve').nodeResolve;

console.log('Initializing Karma with Koa Node Resolve Proxy Server');
console.log('-----------------------------------------------------');

// The `portfinder` package will check for available ports, starting
// with 9876 and ascending until it reaches the OS limit.
portfinder.getPort({port: 9876}, (_err: unknown, port: number) => {
  let karmaServerProxy = async (_ctx: unknown, _next: unknown) => {};
  const proxyPort = port;
  console.log('Starting Proxy Server...');
  const proxyServer =
      new Koa()
          .use(mount('/base', nodeResolve()))
          .use((ctx: unknown, next: unknown) => karmaServerProxy(ctx, next))
          .listen(proxyPort);
  process.on('SIGINT', () => proxyServer.close())
  console.log('Proxy Server listening on port', proxyPort);

  console.log('Starting Karma Server...');
  const karmaConfig = {
    configFile: path.join(__dirname, '../karma.conf.js'),
    upstreamProxy: {hostname: '127.0.0.1', port: proxyPort},
    port: proxyPort + 1,
    singleRun: process.argv.indexOf('--single-run') !== -1,
  };
  const karmaServer = new karma.Server(karmaConfig, (exitCode: number) => {
    console.log('Karma has exited with ' + exitCode);
    process.exit(exitCode);
  });
  karmaServer.on('listening', (port: number) => {
    const karmaPort = port;
    console.log('Karma Server listening on port', karmaPort);
    karmaServerProxy = proxy({host: `http://127.0.0.1:${karmaPort}/`});
  });
  karmaServer.start();
});
```

And that is a lot of boilerplate to require anyone copy into their apps just to test elements with karma.

If this tool bundled that nonsense up, we could get rid of that file and replace it with a top-level `karma.proxy.js` file with the following contents:

```js
const Koa = require('koa');
const mount = require('koa-mount');
const {nodeResolve} = require('koa-node-resolve');
module.exports = (karma) => new Koa()
    .use(mount('/base', nodeResolve())
    .use(karma);
```

Who wouldn't want to live in that world?  This doesn't preclude a future where the proxy configuration including the proxy server itself disappears into another tool `karma-web-modules` or whatever that automatically sets up the proxy to use koa-node-resolve and koa-esm-to-amd etc, essentially running karma with nextgen polyserve etc, but this is the stepping stone and would be a dependency of that configuration.