### PR TITLE
Set default port to 9876

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ## Unreleased -->
 <!-- Add new unreleased items here -->
 
+## [1.0.0-pre.4] - 2019-08-08
+
+ - Make it possible to specify upstream proxy port through more common vectors:
+   - Add a `--proxyPort` CLI flag
+   - Add an `upstreamProxyPort` option in `start()`
+ - Default the upstream proxy port to 9876.
+
 ## [1.0.0-pre.3] - 2019-08-06
 
  - Fixed the karma-proxy CLI; was missing shebang directive.
 
 ## [1.0.0-pre.2] - 2019-08-06
 
-- Initial release.
+ - Initial release.

--- a/README.md
+++ b/README.md
@@ -51,10 +51,13 @@ This will:
 4. wait for karma to confirm the port it is listening on.
 5. configure the proxy middleware to start directing requests to karma.
 
-If you want to name your `karma.proxy.js` file differently or put it somewhere else, use the `--proxyFile` command-line argument to specify it like:
+The wrapper supports two optional flags:
+
+ - `--proxyFile` to point to a file other than `karma.proxy.js`.
+ - `--proxyPort` to specify a starting port other than the default `9876` to start the upstream proxy server on.
 
 ```sh
-$ npx karma-proxy start --proxyFile ./lib/my-proxy.js
+$ npx karma-proxy start --proxyFile ./lib/my-proxy.js --proxyPort 30330
 ```
 
 ## Advanced Usage

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This will:
 4. wait for karma to confirm the port it is listening on.
 5. configure the proxy middleware to start directing requests to karma.
 
-The wrapper supports two optional flags:
+The wrapper supports two optional flags in addition to all the ones in the standard `karma` CLI:
 
  - `--proxyFile` to point to a file other than `karma.proxy.js`.
  - `--proxyPort` to specify a starting port other than the default `9876` to start the upstream proxy server on.

--- a/README.md
+++ b/README.md
@@ -56,8 +56,9 @@ The wrapper supports two optional flags in addition to all the ones in the stand
  - `--proxyFile` to point to a file other than `karma.proxy.js`.
  - `--proxyPort` to specify a starting port other than the default `9876` to start the upstream proxy server on.
 
+Please note, when using `npx`, flags given to `karma-proxy` should follow a `--` separator so they are not treated as `npx` flags:
 ```sh
-$ npx karma-proxy start --proxyFile ./lib/my-proxy.js --proxyPort 30330
+$ npx karma-proxy start -- --proxyFile ./lib/my-proxy.js --proxyPort 30330
 ```
 
 ## Advanced Usage

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,8 +17,7 @@ import karma = require('karma');
 import {resolve as resolvePath} from 'path';
 import {extractArgv} from './utils';
 
-export const run =
-    async(argv: Array<string>): Promise<number> => new Promise((resolve) => {
+export const run = (argv: string[]) => new Promise<number>((resolve) => {
   console.log('Karma Proxy wrapper for Karma CLI');
   let upstreamProxyServerFactory;
 
@@ -31,10 +30,12 @@ export const run =
   })();
 
   const {process: processKarmaArgs} = require('karma/lib/cli');
+
+  console.info(
+      `  --proxyFile <path>   Default is ./karma.proxy.js\n` +
+      `  --proxyPort <port>   Default is 9876\n`);
+
   const karmaConfig: karma.ConfigOptions = processKarmaArgs();
-  const showUsageInfo = () => console.info(
-      `You can override the default proxy config file path of "./karma.proxy.js" by adding the option:\n` +
-      `${argv[1]} ${argv[2]} --proxyFile <path>\n`);
 
   try {
     upstreamProxyServerFactory = require(karmaProxyConfigFile);
@@ -43,7 +44,6 @@ export const run =
         `Unable to load proxy server config file "${
             karmaProxyConfigFile}" due to`,
         err);
-    showUsageInfo();
     resolve(1);
   }
 
@@ -52,7 +52,7 @@ export const run =
         await start(upstreamProxyServerFactory, {
           upstreamProxyPort: proxyPortOption,
           karmaConfig,
-          karmaExitCallback: resolve
+          karmaExitCallback: resolve,
         });
     console.log(
         `[karma-proxy] Upstream Proxy Server started at ` +

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,11 @@ export const run =
   const karmaProxyConfigFile =
       resolvePath(extractArgv('--proxyFile', argv) || './karma.proxy.js');
 
+  const proxyPortOption: number|undefined = (() => {
+    const port = extractArgv('--proxyPort', argv);
+    return port ? parseInt(port) : undefined;
+  })();
+
   const {process: processKarmaArgs} = require('karma/lib/cli');
   const karmaConfig: karma.ConfigOptions = processKarmaArgs();
   const showUsageInfo = () => console.info(
@@ -43,8 +48,12 @@ export const run =
   }
 
   (async () => {
-    const {upstreamProxyPort, karmaPort} = await start(
-        upstreamProxyServerFactory, {karmaConfig, karmaExitCallback: resolve});
+    const {upstreamProxyPort, karmaPort} =
+        await start(upstreamProxyServerFactory, {
+          upstreamProxyPort: proxyPortOption,
+          karmaConfig,
+          karmaExitCallback: resolve
+        });
     console.log(
         `[karma-proxy] Upstream Proxy Server started at ` +
         `http://0.0.0.0:${upstreamProxyPort}/ and proxying to karma port ${

--- a/src/karma-proxy.ts
+++ b/src/karma-proxy.ts
@@ -54,6 +54,7 @@ interface ConfigFile {
 export type Options = {
   karmaConfig?: karma.ConfigOptions|ConfigFile,
   karmaExitCallback?: (exitCode: number) => void,
+  upstreamProxyPort?: number,
 };
 
 export type Servers = {
@@ -78,6 +79,8 @@ export const start = async(
   const karmaConfig: ConfigOptions =
       options && options.karmaConfig as karma.ConfigOptions || {};
   const karmaConfigFile: ConfigFile = karmaConfig as ConfigFile;
+  const startingUpstreamProxyPort: number =
+      options && options.upstreamProxyPort || 9876;
   if (karmaConfigFile.configFile) {
     const {configFile} = karmaConfigFile;
     const configSetter = karma.config.parseConfig(configFile, karmaConfig);
@@ -169,11 +172,5 @@ export const start = async(
     karmaServer.on('close', () => upstreamProxyServer.close());
   };
 
-  // Karma's default upstreamProxy server port setting is 9875.  We'll start
-  // looking for ports based on the port specified in the karma config for
-  // upstreamProxy, but that's just a starting point.  `portfinder` will
-  // settle on the first available one in ascending order, starting with
-  // that one.
-  startUpstreamProxyServer(
-      karmaConfig.upstreamProxy && karmaConfig.upstreamProxy.port || 9875);
+  startUpstreamProxyServer(startingUpstreamProxyPort);
 });


### PR DESCRIPTION
 - Make it possible to specify upstream proxy port through more common vectors:
   - Add a `--proxyPort` CLI flag
   - Add an `upstreamProxyPort` option in `start()`
 - Default the upstream proxy port to 9876.

Fixes #5 and #6 