### PR TITLE
Added the --proxyHostname and --proxyAddress options to CLI.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    Unreleased section, uncommenting the header as necessary.
 -->
 
-<!-- ## Unreleased -->
+## Unreleased 
+
+ - Added a `--proxyHost` CLI flag
+ - Added an `upstreamProxyHost` option in `start()`
+
 <!-- Add new unreleased items here -->
 
 ## [1.0.0-pre.4] - 2019-08-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased 
 
- - Added a `--proxyHost` CLI flag
- - Added an `upstreamProxyHost` option in `start()`
+ - Added a `--proxyAddress` and `--proxyHostname` CLI flags
+ - Added an `upstreamProxyAddress` and `upstreamProxyHostname` options in `start()`
+ - Include `karmaAddress`, `karmaHostname`, `upstreamProxyAddress` and `upstreamProxyHostname` in `start()` async response.
 
 <!-- Add new unreleased items here -->
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ This will:
 The wrapper supports two optional flags in addition to all the ones in the standard `karma` CLI:
 
  - `--proxyFile` to point to a file other than `karma.proxy.js`.
- - `--proxyHost` to specify a host name/IP for the proxy to listen on other than the default `localhost`.
+ - `--proxyAddress` to specify a host name/IP for the proxy to listen on other than the default `0.0.0.0`.
+ - `--proxyHostname` to specify a host name/IP to direct browsers to other than the default `localhost`.
  - `--proxyPort` to specify a starting port other than the default `9876` to start the upstream proxy server on.
 
 Please note, when using `npx`, flags given to `karma-proxy` should follow a `--` separator so they are not treated as `npx` flags:

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This will:
 The wrapper supports two optional flags in addition to all the ones in the standard `karma` CLI:
 
  - `--proxyFile` to point to a file other than `karma.proxy.js`.
+ - `--proxyHost` to specify a host name/IP for the proxy to listen on other than the default `localhost`.
  - `--proxyPort` to specify a starting port other than the default `9876` to start the upstream proxy server on.
 
 Please note, when using `npx`, flags given to `karma-proxy` should follow a `--` separator so they are not treated as `npx` flags:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1963,6 +1963,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -1970,7 +1971,8 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
         }
       }
     },
@@ -2179,23 +2181,6 @@
       "resolved": "https://registry.npmjs.org/plur/-/plur-1.0.0.tgz",
       "integrity": "sha1-24XGgU9eXlo7Se/CjWBP7GKXUVY=",
       "dev": true
-    },
-    "portfinder": {
-      "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.21.tgz",
-      "integrity": "sha512-ESabpDCzmBS3ekHbmpAIiESq3udRsCBGiBZLsC+HgBKv2ezb0R4oG+7RnYEVZ/ZCfhel5Tx3UzdNWA0Lox2QCA==",
-      "requires": {
-        "async": "^1.5.2",
-        "debug": "^2.2.0",
-        "mkdirp": "0.5.x"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        }
-      }
     },
     "pretty-ms": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
   },
   "dependencies": {
     "karma": "^4.1.0",
-    "koa-proxy": "^1.0.0-alpha.3",
-    "portfinder": "^1.0.20"
+    "koa-proxy": "^1.0.0-alpha.3"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,7 +24,8 @@ export const run = (argv: string[]) => new Promise<number>((resolve) => {
   const karmaProxyConfigFile =
       resolvePath(extractArgv('--proxyFile', argv) || './karma.proxy.js');
 
-  const proxyHostOption: string = extractArgv('--proxyHost', argv);
+  const proxyHostnameOption: string = extractArgv('--proxyHostname', argv);
+  const proxyAddressOption: string = extractArgv('--proxyAddress', argv);
 
   const proxyPortOption: number|undefined = (() => {
     const port = extractArgv('--proxyPort', argv);
@@ -34,11 +35,14 @@ export const run = (argv: string[]) => new Promise<number>((resolve) => {
   const {process: processKarmaArgs} = require('karma/lib/cli');
 
   console.info(
-      `  --proxyFile <path>      ${
+      `  --proxyFile     <path>      ${
           karmaProxyConfigFile || 'Default is ./karma.proxy.js'}\n` +
-      `  --proxyHost <hostname>  ${
-          proxyHostOption || 'Default is localhost'}\n` +
-      `  --proxyPort <port>      ${proxyPortOption || 'Default is 9876'}\n`);
+      `  --proxyAddress  <address>   ${
+          proxyAddressOption || 'Default is 0.0.0.0'}\n` +
+      `  --proxyHostname <hostname>  ${
+          proxyHostnameOption || 'Default is localhost'}\n` +
+      `  --proxyPort     <port>      ${
+          proxyPortOption || 'Default is 9876'}\n`);
 
   const karmaConfig: karma.ConfigOptions = processKarmaArgs();
 
@@ -53,16 +57,23 @@ export const run = (argv: string[]) => new Promise<number>((resolve) => {
   }
 
   (async () => {
-    const {upstreamProxyHost, upstreamProxyPort, karmaHost, karmaPort} =
-        await start(upstreamProxyServerFactory, {
-          upstreamProxyHost: proxyHostOption,
-          upstreamProxyPort: proxyPortOption,
-          karmaConfig,
-          karmaExitCallback: resolve,
-        });
+    const {
+      upstreamProxyAddress,
+      upstreamProxyHostname,
+      upstreamProxyPort,
+      karmaHostname,
+      karmaPort
+    } = await start(upstreamProxyServerFactory, {
+      upstreamProxyAddress: proxyAddressOption,
+      upstreamProxyHostname: proxyHostnameOption,
+      upstreamProxyPort: proxyPortOption,
+      karmaConfig,
+      karmaExitCallback: resolve,
+    });
     console.log(
         `[karma-proxy] Upstream Proxy Server started at ` +
-        `http://${upstreamProxyHost}:${upstreamProxyPort}/ ` +
-        `and proxy to karma at ${karmaHost}:${karmaPort}`);
+        `http://${upstreamProxyHostname}:${upstreamProxyPort}/ ` +
+        `(${upstreamProxyAddress}) ` +
+        `and proxy to karma at ${karmaHostname}:${karmaPort}`);
   })();
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,14 +55,14 @@ export const run = (argv: string[]) => new Promise<number>((resolve) => {
   (async () => {
     const {upstreamProxyHost, upstreamProxyPort, karmaHost, karmaPort} =
         await start(upstreamProxyServerFactory, {
+          upstreamProxyHost: proxyHostOption,
           upstreamProxyPort: proxyPortOption,
           karmaConfig,
           karmaExitCallback: resolve,
         });
     console.log(
         `[karma-proxy] Upstream Proxy Server started at ` +
-        `http://${upstreamProxyHost}:${
-            upstreamProxyPort}/ and proxy ro karma at ${karmaHost}:${
-            karmaPort}`);
+        `http://${upstreamProxyHost}:${upstreamProxyPort}/ ` +
+        `and proxy to karma at ${karmaHost}:${karmaPort}`);
   })();
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,8 @@ export const run = (argv: string[]) => new Promise<number>((resolve) => {
   const karmaProxyConfigFile =
       resolvePath(extractArgv('--proxyFile', argv) || './karma.proxy.js');
 
+  const proxyHostOption: string = extractArgv('--proxyHost', argv);
+
   const proxyPortOption: number|undefined = (() => {
     const port = extractArgv('--proxyPort', argv);
     return port ? parseInt(port) : undefined;
@@ -32,8 +34,11 @@ export const run = (argv: string[]) => new Promise<number>((resolve) => {
   const {process: processKarmaArgs} = require('karma/lib/cli');
 
   console.info(
-      `  --proxyFile <path>   Default is ./karma.proxy.js\n` +
-      `  --proxyPort <port>   Default is 9876\n`);
+      `  --proxyFile <path>      ${
+          karmaProxyConfigFile || 'Default is ./karma.proxy.js'}\n` +
+      `  --proxyHost <hostname>  ${
+          proxyHostOption || 'Default is localhost'}\n` +
+      `  --proxyPort <port>      ${proxyPortOption || 'Default is 9876'}\n`);
 
   const karmaConfig: karma.ConfigOptions = processKarmaArgs();
 
@@ -48,7 +53,7 @@ export const run = (argv: string[]) => new Promise<number>((resolve) => {
   }
 
   (async () => {
-    const {upstreamProxyPort, karmaPort} =
+    const {upstreamProxyHost, upstreamProxyPort, karmaHost, karmaPort} =
         await start(upstreamProxyServerFactory, {
           upstreamProxyPort: proxyPortOption,
           karmaConfig,
@@ -56,7 +61,8 @@ export const run = (argv: string[]) => new Promise<number>((resolve) => {
         });
     console.log(
         `[karma-proxy] Upstream Proxy Server started at ` +
-        `http://0.0.0.0:${upstreamProxyPort}/ and proxying to karma port ${
+        `http://${upstreamProxyHost}:${
+            upstreamProxyPort}/ and proxy ro karma at ${karmaHost}:${
             karmaPort}`);
   })();
 });

--- a/src/karma-proxy.ts
+++ b/src/karma-proxy.ts
@@ -54,6 +54,7 @@ interface ConfigFile {
 export type Options = {
   karmaConfig?: karma.ConfigOptions|ConfigFile,
   karmaExitCallback?: (exitCode: number) => void,
+  upstreamProxyHost?: string,
   upstreamProxyPort?: number,
 };
 
@@ -81,6 +82,8 @@ export const start = async(
   const karmaConfigFile: ConfigFile = karmaConfig as ConfigFile;
   const startingUpstreamProxyPort: number =
       options && options.upstreamProxyPort || 9876;
+  const upstreamProxyHost: string =
+      options && options.upstreamProxyHost || 'localhost';
   if (karmaConfigFile.configFile) {
     const {configFile} = karmaConfigFile;
     const configSetter = karma.config.parseConfig(configFile, karmaConfig);
@@ -132,7 +135,7 @@ export const start = async(
           }
           try {
             lastUpstreamProxyPortTried = upstreamProxyPort;
-            upstreamProxyServer.listen(upstreamProxyPort);
+            upstreamProxyServer.listen(upstreamProxyPort, upstreamProxyHost);
           } catch (err) {
             return retryOrReject(upstreamProxyPort, err);
           }

--- a/src/test/karma-proxy.test.ts
+++ b/src/test/karma-proxy.test.ts
@@ -28,7 +28,34 @@ test('starts a proxy server and karma server and it works', async (t) => {
         karmaConfig: {
           basePath: path.join(__dirname, '../..'),
           files: [{pattern: './test/*.js', included: false, served: true}]
-        }
+        },
+        karmaExitCallback: () => undefined,
+      });
+
+  const responseText =
+      (await request(upstreamProxyServer).get('/base/example.js')).text;
+
+  upstreamProxyServer.close(() => {
+    stopper.stop({port: karmaPort}, () => {
+      t.isNotEqual(responseText, undefined, `Response text should be defined`);
+      t.equal(
+          responseText,
+          '/* :) */something();\n',
+          `Response text should contain the prepended content`);
+    });
+  });
+});
+
+test('starts a proxy server on the given host', async (t) => {
+  t.plan(2);
+  const {karmaPort, upstreamProxyServer} =
+      await start(upstreamProxyServerFactory, {
+        karmaConfig: {
+          basePath: path.join(__dirname, '../..'),
+          files: [{pattern: './test/*.js', included: false, served: true}],
+        },
+        upstreamProxyHost: '0.0.0.0',
+        karmaExitCallback: () => undefined,
       });
 
   const responseText =

--- a/src/test/karma-proxy.test.ts
+++ b/src/test/karma-proxy.test.ts
@@ -22,21 +22,33 @@ import {start} from '../karma-proxy';
 const upstreamProxyServerFactory = require('../../test/karma.proxy.js');
 
 test('starts a proxy server and karma server and it works', async (t) => {
-  t.plan(2);
-  const {karmaPort, upstreamProxyServer} =
-      await start(upstreamProxyServerFactory, {
-        karmaConfig: {
-          basePath: path.join(__dirname, '../..'),
-          files: [{pattern: './test/*.js', included: false, served: true}]
-        },
-        karmaExitCallback: () => undefined,
-      });
+  t.plan(4);
+  const {
+    karmaPort,
+    upstreamProxyAddress,
+    upstreamProxyHostname,
+    upstreamProxyServer
+  } = await start(upstreamProxyServerFactory, {
+    karmaConfig: {
+      basePath: path.join(__dirname, '../..'),
+      files: [{pattern: './test/*.js', included: false, served: true}]
+    },
+    karmaExitCallback: () => undefined,
+  });
 
   const responseText =
       (await request(upstreamProxyServer).get('/base/example.js')).text;
 
   upstreamProxyServer.close(() => {
     stopper.stop({port: karmaPort}, () => {
+      t.equal(
+          upstreamProxyAddress,
+          '0.0.0.0',
+          'Proxy should listen on default address');
+      t.equal(
+          upstreamProxyHostname,
+          'localhost',
+          'Proxy should listen on default host');
       t.isNotEqual(responseText, undefined, `Response text should be defined`);
       t.equal(
           responseText,
@@ -47,22 +59,35 @@ test('starts a proxy server and karma server and it works', async (t) => {
 });
 
 test('starts a proxy server on the given host', async (t) => {
-  t.plan(2);
-  const {karmaPort, upstreamProxyServer} =
-      await start(upstreamProxyServerFactory, {
-        karmaConfig: {
-          basePath: path.join(__dirname, '../..'),
-          files: [{pattern: './test/*.js', included: false, served: true}],
-        },
-        upstreamProxyHost: '0.0.0.0',
-        karmaExitCallback: () => undefined,
-      });
+  t.plan(4);
+  const {
+    karmaPort,
+    upstreamProxyAddress,
+    upstreamProxyHostname,
+    upstreamProxyServer
+  } = await start(upstreamProxyServerFactory, {
+    karmaConfig: {
+      basePath: path.join(__dirname, '../..'),
+      files: [{pattern: './test/*.js', included: false, served: true}],
+    },
+    upstreamProxyAddress: '127.0.0.1',
+    upstreamProxyHostname: 'whatever-i-say',
+    karmaExitCallback: () => undefined,
+  });
 
   const responseText =
       (await request(upstreamProxyServer).get('/base/example.js')).text;
 
   upstreamProxyServer.close(() => {
     stopper.stop({port: karmaPort}, () => {
+      t.equal(
+          upstreamProxyAddress,
+          '127.0.0.1',
+          'Proxy should listen on given address');
+      t.equal(
+          upstreamProxyHostname,
+          'whatever-i-say',
+          'Proxy should listen on given hostname');
       t.isNotEqual(responseText, undefined, `Response text should be defined`);
       t.equal(
           responseText,


### PR DESCRIPTION
This was added, essentially, to better enable workarounds for when localhost isn't available to run on some VMs or versions and to bring the proxy into parity with karma's config options.